### PR TITLE
work around sched_param having more members on some platforms

### DIFF
--- a/bark/src/thread.rs
+++ b/bark/src/thread.rs
@@ -12,15 +12,11 @@ pub fn set_name(name: &str) {
 }
 
 pub fn set_realtime_priority() {
-    let rc = unsafe {
-        libc::sched_setscheduler(
-            0,
-            libc::SCHED_FIFO,
-            &libc::sched_param {
-                sched_priority: 99,
-            }
-        )
-    };
+    // work around the libc crate exposing more struct members on some libc's
+    let mut sched_param: libc::sched_param = unsafe { std::mem::zeroed() };
+    sched_param.sched_priority = 99;
+
+    let rc = unsafe { libc::sched_setscheduler(0, libc::SCHED_FIFO, &sched_param) };
 
     if rc < 0 {
         static WARNED: AtomicBool = AtomicBool::new(false);


### PR DESCRIPTION
closes #4  

---

i don't know how to write this without unsafe. normally Default::default() exists but it's not implemented in this case..