### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ low latency multi-receiver synchronised audio streaming for local networks.
 
 * Built-in time synchronisation and latency detection - no high precision NTP required!
 
-* Adjusts audio playback rate with the Speex resampler to stay in sync
+* Adjusts audio playback rate with soxr to stay in sync
 
 ### Running the server under Pipewire or Pulse
 

--- a/bark-protocol/src/types.rs
+++ b/bark-protocol/src/types.rs
@@ -27,10 +27,9 @@ pub struct PacketHeader {
 /// our network Packet struct
 /// we don't need to worry about endianness, because according to the rust docs:
 ///
-///     Floats and Ints have the same endianness on all supported platforms.
-///     IEEE 754 very precisely specifies the bit layout of floats.
-///
-///     - https://doc.rust-lang.org/std/primitive.f32.html
+/// > Floats and Ints have the same endianness on all supported platforms.
+/// > IEEE 754 very precisely specifies the bit layout of floats.
+/// - https://doc.rust-lang.org/std/primitive.f32.html
 #[derive(Debug, Clone, Copy, Zeroable, Pod)]
 #[repr(C)]
 pub struct AudioPacketHeader {

--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -30,7 +30,6 @@ depends=(
     "alsa-lib"
     "gcc-libs"
     "opus"
-    "speexdsp"
 )
 makedepends=("cargo")
 arch=("x86_64")


### PR DESCRIPTION
This removes mention of speex from readme/pkgbuild since (AFAICT?) bark doesn't use it any more

I've also fixed a rustdoc comment which would cause test failures, since rustdoc sees indented blocks as code to be run :-)
